### PR TITLE
feat: outlet으로 web/mobile layout 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider } from 'styled-components';
 import GlobalStyle from '@styles/GlobalStyle';
 import theme from '@styles/theme';
 
-function App() {
+export default function App() {
   return (
     <BrowserRouter>
       <ThemeProvider theme={theme}>
@@ -15,5 +15,3 @@ function App() {
     </BrowserRouter>
   );
 }
-
-export default App;

--- a/src/components/layout/MobileLayout.tsx
+++ b/src/components/layout/MobileLayout.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Outlet } from 'react-router';
+import styled from 'styled-components';
+
+export default function MobileLayout() {
+  return (
+    <Layout>
+      <Outlet />
+    </Layout>
+  );
+}
+
+const Layout = styled.div`
+  width: 375px;
+  height: 100vh;
+  border: 1px solid #ccc;
+  margin: 0 auto;
+  overflow-y: scroll;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`;

--- a/src/components/layout/WebLayout.tsx
+++ b/src/components/layout/WebLayout.tsx
@@ -1,23 +1,20 @@
 import React from 'react';
+import { Outlet } from 'react-router';
 import styled from 'styled-components';
 
-interface LayoutProps {
-  children: React.ReactNode;
-}
-
-function Layout({ children }: LayoutProps) {
+export default function WebLayout() {
   return (
-    <LayoutContainer>
+    <WebLayoutContainer>
       <Header />
       <SideBar />
-      <Main>{children}</Main>
-    </LayoutContainer>
+      <Main>
+        <Outlet />
+      </Main>
+    </WebLayoutContainer>
   );
 }
 
-export default Layout;
-
-const LayoutContainer = styled.div`
+const WebLayoutContainer = styled.div`
   display: grid;
   position: fixed;
   width: 100%;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,8 +1,5 @@
-import Layout from '@components/layout/Layout';
 import React from 'react';
 
-function Admin() {
-  return <Layout>Admin</Layout>;
+export default function Admin() {
+  return <div>Admin</div>;
 }
-
-export default Admin;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-function Home() {
+export default function Home() {
   return (
     <HomeContainer>
       <StyledLink to="user">User</StyledLink>
@@ -10,8 +10,6 @@ function Home() {
     </HomeContainer>
   );
 }
-
-export default Home;
 
 const HomeContainer = styled.div`
   width: 30vw;

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -1,19 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
 
-function User() {
-  return <UserContainer>user</UserContainer>;
+export default function User() {
+  return <div>user</div>;
 }
-
-export default User;
-
-const UserContainer = styled.div`
-  width: 375px;
-  height: 100vh;
-  border: 1px solid #ccc;
-  margin: 0 auto;
-  overflow-y: scroll;
-  ::-webkit-scrollbar {
-    display: none;
-  }
-`;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -4,15 +4,19 @@ import { Route, Routes } from 'react-router';
 import Admin from '@pages/Admin';
 import Home from '@pages/Home';
 import User from '@pages/User';
+import MobileLayout from '@components/layout/MobileLayout';
+import WebLayout from '@components/layout/WebLayout';
 
-function Router() {
+export default function Router() {
   return (
     <Routes>
       <Route path="" element={<Home />} />
-      <Route path="user" element={<User />} />
-      <Route path="admin" element={<Admin />} />
+      <Route element={<MobileLayout />}>
+        <Route path="user" element={<User />} />
+      </Route>
+      <Route element={<WebLayout />}>
+        <Route path="admin" element={<Admin />} />
+      </Route>
     </Routes>
   );
 }
-
-export default Router;


### PR DESCRIPTION
## 개요
웹/앱 layout 적용

## 작업사항
이전 admin에만 적용되어있는 layout을 좀더 확장성있게 사용하기위해,
route/ outlet을 이용하여 mobile과 web의 layout을 각각 적용했습니다

## 사용 방법
layout에 수정이 필요하시면 components/layout폴더안에 해당 파일에서 수정하시면 됩니다 
