### PR TITLE
feat: admin 페이지 데이터 테이블로 보여주기

### DIFF
--- a/src/components/applicant/ApplicantContainer.tsx
+++ b/src/components/applicant/ApplicantContainer.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
+import styled from 'styled-components';
 
-function ApplicantContainer() {
-  return <div>ApplicantContainer</div>;
+import ApplicantList from '@components/applicant/ApplicantList';
+
+function ApplicantConainer() {
+  return (
+    <ApplicantWrapper>
+      <ApplicantList />
+    </ApplicantWrapper>
+  );
 }
 
-export default ApplicantContainer;
+const ApplicantWrapper = styled.div`
+  width: 100%;
+`;
+
+export default ApplicantConainer;

--- a/src/components/applicant/ApplicantContainer.tsx
+++ b/src/components/applicant/ApplicantContainer.tsx
@@ -11,11 +11,14 @@ function ApplicantConainer() {
 
   React.useEffect(() => {
     async function getUserData() {
-      const userData = await axios.get('/db.json');
-      setUserList(userData.data.users);
-
-      const keyData = Object.keys(userData.data.users[0]);
-      setKeyList(keyData);
+      try {
+        const userData = await axios.get(`/db.json`);
+        setUserList(userData.data.users);
+        const keyData = Object.keys(userData.data.users[0]);
+        setKeyList(keyData);
+      } catch (error) {
+        console.log(error);
+      }
     }
     getUserData();
   }, []);
@@ -34,7 +37,7 @@ function ApplicantConainer() {
 
 const ApplicantWrapper = styled.div`
   width: 100%;
-  height: 1115px;
+  height: 70vh;
   background: #f3f3f3;
   border: 1px solid red;
 `;

--- a/src/components/applicant/ApplicantContainer.tsx
+++ b/src/components/applicant/ApplicantContainer.tsx
@@ -1,18 +1,50 @@
 import React from 'react';
 import styled from 'styled-components';
+import axios from 'axios';
 
 import ApplicantList from '@components/applicant/ApplicantList';
 
 function ApplicantConainer() {
+  const [userList, setUserList] = React.useState([]);
+  const [keyList, setKeyList] = React.useState<Array<string>>([]);
+  const [filterUserList, setFilterUserList] = React.useState([]);
+
+  React.useEffect(() => {
+    async function getUserData() {
+      const userData = await axios.get('/db.json');
+      setUserList(userData.data.users);
+
+      const keyData = Object.keys(userData.data.users[0]);
+      setKeyList(keyData);
+    }
+    getUserData();
+  }, []);
+
+  const userListFilter = () => {
+    return setFilterUserList(userList);
+  };
+
   return (
     <ApplicantWrapper>
-      <ApplicantList />
+      <ApplicantOrder onClick={userListFilter}>1차 모집</ApplicantOrder>
+      <ApplicantList userList={filterUserList} keyList={keyList} />
     </ApplicantWrapper>
   );
 }
 
 const ApplicantWrapper = styled.div`
   width: 100%;
+  height: 1115px;
+  background: #f3f3f3;
+  border: 1px solid red;
+`;
+
+const ApplicantOrder = styled.div`
+  text-align: center;
+  font-weight: 700;
+  font-size: 15px;
+  line-height: 22px;
+  cursor: pointer;
 `;
 
 export default ApplicantConainer;

--- a/src/components/applicant/ApplicantContainer.tsx
+++ b/src/components/applicant/ApplicantContainer.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function ApplicantContainer() {
+  return <div>ApplicantContainer</div>;
+}
+
+export default ApplicantContainer;

--- a/src/components/applicant/ApplicantList.tsx
+++ b/src/components/applicant/ApplicantList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { IUser } from '@type/models/user';
+import ApplicantTableRow from '@src/components/applicant/ApplicantTableRow';
 
 interface IApplicantList {
   userList: IUser[];
@@ -35,28 +36,9 @@ function ApplicantList({ userList, keyList }: IApplicantList) {
           ))}
         </ListTableHeadTR>
       </ListTableHead>
-      <ListTableBody>
-        {userList.map((user: IUserObject, index: number) => (
-          <ListTableBodyTR key={index}>
-            {keyList.length > 0 &&
-              keyList.map((item: string, index: number) => {
-                const value = user[item];
-                if (item === 'win') {
-                  return (
-                    <ListTableTD key={index}>
-                      {user[item] ? (
-                        <input type="checkbox" defaultChecked />
-                      ) : (
-                        <input type="checkbox" />
-                      )}
-                    </ListTableTD>
-                  );
-                }
-                return <ListTableTD key={index}>{value}</ListTableTD>;
-              })}
-          </ListTableBodyTR>
-        ))}
-      </ListTableBody>
+      {userList.map((user: IUserObject, index: number) => (
+        <ApplicantTableRow key={index} user={user} />
+      ))}
     </ListTable>
   );
 }
@@ -91,14 +73,6 @@ const ListTableTH = styled.th`
     width: 1%;
     white-space: nowrap;
   }
-`;
-
-const ListTableBody = styled.tbody``;
-
-const ListTableBodyTR = styled.tr``;
-
-const ListTableTD = styled.td`
-  padding: 2px;
 `;
 
 export default ApplicantList;

--- a/src/components/applicant/ApplicantList.tsx
+++ b/src/components/applicant/ApplicantList.tsx
@@ -1,7 +1,109 @@
 import React from 'react';
+import styled from 'styled-components';
+import axios from 'axios';
 
 function ApplicantList() {
-  return <div>ApplicantList</div>;
+  const [data, setData] = React.useState([]);
+  const [keyList, setKeyList] = React.useState<Array<string>>([]);
+
+  React.useEffect(() => {
+    async function getUserData() {
+      const userData = await axios.get('/db.json');
+      setData(userData.data.users);
+
+      const keyData = Object.keys(userData.data.users[0]);
+      setKeyList(keyData);
+    }
+    getUserData();
+  }, []);
+
+  const titleList: string[] = [
+    'Num.',
+    '지원날짜',
+    '지원자명',
+    '성별',
+    '생년월일',
+    '연락처',
+    '이메일',
+    '이용수단',
+    '거주지',
+    '당첨여부',
+  ];
+
+  return (
+    <ListTable>
+      <ListTableHead>
+        <ListTableHeadTR>
+          {titleList.map((item, index) => (
+            <ListTableTH key={index}>{item}</ListTableTH>
+          ))}
+        </ListTableHeadTR>
+      </ListTableHead>
+      <ListTableBody>
+        {data.map((object, index) => (
+          <ListTableBodyTR key={index}>
+            {keyList.length > 0 &&
+              keyList.map((item, index) => {
+                const value = object[item];
+                if (item === 'win') {
+                  return (
+                    <ListTableTD key={index}>
+                      {object[item] ? (
+                        <input type="checkbox" defaultChecked />
+                      ) : (
+                        <input type="checkbox" />
+                      )}
+                    </ListTableTD>
+                  );
+                }
+                return <ListTableTD key={index}>{value}</ListTableTD>;
+              })}
+          </ListTableBodyTR>
+        ))}
+      </ListTableBody>
+    </ListTable>
+  );
 }
+
+const ListTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  text-align: center;
+  border-radius: 5px;
+  overflow: hidden;
+`;
+
+const ListTableHead = styled.thead`
+  position: sticky;
+  font-weight: 600;
+  z-index: 100;
+`;
+
+const ListTableHeadTR = styled.tr`
+  background: #f3f3f3;
+`;
+
+const ListTableTH = styled.th`
+  padding: 5px;
+  text-transform: capitalize;
+
+  :not(:last-of-type) {
+    border-right: 1px solid ${({ theme }) => theme.color.grey_01};
+  }
+  :first-of-type {
+    width: 1%;
+    white-space: nowrap;
+  }
+`;
+
+const ListTableBody = styled.tbody``;
+
+const ListTableBodyTR = styled.tr`
+  background: #f3f3f3;
+`;
+
+const ListTableTD = styled.td`
+  padding: 2px;
+`;
 
 export default ApplicantList;

--- a/src/components/applicant/ApplicantList.tsx
+++ b/src/components/applicant/ApplicantList.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
 import styled from 'styled-components';
-import axios from 'axios';
 
-function ApplicantList() {
-  const [data, setData] = React.useState([]);
-  const [keyList, setKeyList] = React.useState<Array<string>>([]);
+import { IUser } from '@type/models/user';
 
-  React.useEffect(() => {
-    async function getUserData() {
-      const userData = await axios.get('/db.json');
-      setData(userData.data.users);
+interface IApplicantList {
+  userList: IUser[];
+  keyList: string[];
+}
 
-      const keyData = Object.keys(userData.data.users[0]);
-      setKeyList(keyData);
-    }
-    getUserData();
-  }, []);
+interface IUserObject {
+  [key: string]: any;
+}
 
+function ApplicantList({ userList, keyList }: IApplicantList) {
   const titleList: string[] = [
     'Num.',
     '지원날짜',
@@ -40,15 +36,15 @@ function ApplicantList() {
         </ListTableHeadTR>
       </ListTableHead>
       <ListTableBody>
-        {data.map((object, index) => (
+        {userList.map((user: IUserObject, index: number) => (
           <ListTableBodyTR key={index}>
             {keyList.length > 0 &&
-              keyList.map((item, index) => {
-                const value = object[item];
+              keyList.map((item: string, index: number) => {
+                const value = user[item];
                 if (item === 'win') {
                   return (
                     <ListTableTD key={index}>
-                      {object[item] ? (
+                      {user[item] ? (
                         <input type="checkbox" defaultChecked />
                       ) : (
                         <input type="checkbox" />
@@ -90,6 +86,7 @@ const ListTableTH = styled.th`
   :not(:last-of-type) {
     border-right: 1px solid ${({ theme }) => theme.color.grey_01};
   }
+
   :first-of-type {
     width: 1%;
     white-space: nowrap;
@@ -98,9 +95,7 @@ const ListTableTH = styled.th`
 
 const ListTableBody = styled.tbody``;
 
-const ListTableBodyTR = styled.tr`
-  background: #f3f3f3;
-`;
+const ListTableBodyTR = styled.tr``;
 
 const ListTableTD = styled.td`
   padding: 2px;

--- a/src/components/applicant/ApplicantList.tsx
+++ b/src/components/applicant/ApplicantList.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function ApplicantList() {
+  return <div>ApplicantList</div>;
+}
+
+export default ApplicantList;

--- a/src/components/applicant/ApplicantTableRow.tsx
+++ b/src/components/applicant/ApplicantTableRow.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import axios from 'axios';
+import styled from 'styled-components';
+
+interface ApplicantTableTRProps {
+  [key: string]: any;
+}
+
+function ApplicantTableRow({ user }: any) {
+  const tableRowRef = React.useRef<any>();
+
+  const handleWinStatus = (e: React.ChangeEvent<HTMLInputElement>) => {
+    console.log(tableRowRef.current.outerText);
+    console.log(e.target.checked);
+    // axios
+    //   .patch(`/db.json?users/${1}`, {
+    //     win: e.target.checked,
+    //   })
+    //   .then(response => {
+    //     console.log(response);
+    //   })
+    //   .catch(error => {
+    //     console.log(error);
+    //   });
+  };
+
+  return (
+    <ListTableBody ref={tableRowRef}>
+      <ListTableTR>
+        <ListTableTD>{user.id}</ListTableTD>
+        <ListTableTD>{user.date}</ListTableTD>
+        <ListTableTD>{user.name}</ListTableTD>
+        <ListTableTD>{user.sex}</ListTableTD>
+        <ListTableTD>{user.birth}</ListTableTD>
+        <ListTableTD>{user.phone}</ListTableTD>
+        <ListTableTD>{user.email}</ListTableTD>
+        <ListTableTD>{user.transportation}</ListTableTD>
+        <ListTableTD>{user.region}</ListTableTD>
+        <ListTableTD>
+          {user.win ? (
+            <input type="checkbox" defaultChecked onChange={handleWinStatus} />
+          ) : (
+            <input type="checkbox" onChange={handleWinStatus} />
+          )}
+        </ListTableTD>
+      </ListTableTR>
+    </ListTableBody>
+  );
+}
+
+const ListTableBody = styled.tbody``;
+const ListTableTR = styled.tr``;
+const ListTableTD = styled.td`
+  padding: 2px;
+`;
+export default ApplicantTableRow;

--- a/src/components/applicant/index.ts
+++ b/src/components/applicant/index.ts
@@ -1,0 +1,2 @@
+export { default as ApplcantContainer } from './ApplicantContainer';
+export { default as ApplicantList } from './ApplicantList';

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -4,15 +4,20 @@ import styled from 'styled-components';
 import Search from '@src/components/admin/search/Search';
 import Download from '@src/components/admin/Download';
 
+import ApplicantContainer from '@src/components/applicant/ApplicantContainer';
+
 export default function Admin() {
   return (
-    <AdminContainer>
-      <Title>AI 학습용 교통 데이터 수집을 위한 크라우드 워커 지원 현황</Title>
-      <Wrap>
-        <Search />
-        <Download />
-      </Wrap>
-    </AdminContainer>
+    <>
+      <AdminContainer>
+        <Title>AI 학습용 교통 데이터 수집을 위한 크라우드 워커 지원 현황</Title>
+        <Wrap>
+          <Search />
+          <Download />
+        </Wrap>
+      </AdminContainer>
+      <ApplicantContainer />
+    </>
   );
 }
 


### PR DESCRIPTION
## 개요
- admin 페이지에서 목업 데이터를 받아와 테이블로 보여주기

## 작업사항
- 테이블 리스트 관련 컴포넌트 생성 (ApplicantContainer, ApplicantList)
- styled-components를 이용해서 데이터를 테이블에 보여줄 CSS 틀 생성
- axios를 이용해서 목업데이터를 갖고옴 

## 사용 방법
- 테이블에서 갖고온 데이터중 하나를 갖고 key 리스트를 뽑아서 테이블의 head로 만들어줌
- key가 'win'의 경우 true, false에 따라 input checkbox 를 보여주게 만들어줌