### PR TITLE
feat: 합격여부 클릭 시 db 데이터 업데이트

### DIFF
--- a/src/components/applicant/ApplicantContainer.tsx
+++ b/src/components/applicant/ApplicantContainer.tsx
@@ -3,10 +3,13 @@ import styled from 'styled-components';
 
 import ApplicantList from '@components/applicant/ApplicantList';
 
-function ApplicantConainer() {
+interface IApplicantProps {
+  userList: object[];
+  setRound: React.Dispatch<React.SetStateAction<number>>;
+}
+
+function ApplicantConainer({ userList, setRound }: IApplicantProps) {
   const [roundIsActive, setRoundIsActive] = React.useState<number>(0);
-  const [keyList, setKeyList] = React.useState<Array<string>>([]);
-  const [filterUserList, setFilterUserList] = React.useState([]);
 
   const handleRoundClick = (index: number) => {
     setRoundIsActive(index);
@@ -14,15 +17,15 @@ function ApplicantConainer() {
 
   const userListFilter = (index: number) => {
     handleRoundClick(index);
-    return;
+    setRound(index + 1);
   };
 
-  const roundList: number[] = [1, 2];
+  const roundList: number[] = [1, 2, 3];
 
   return (
     <ApplicantWrapper>
       <RoundWrapper>
-        {roundList.map((item, index) => (
+        {roundList.map((_, index) => (
           <ApplicantOrder
             style={{
               backgroundColor: roundIsActive === index ? '#f3f3f3' : 'white',
@@ -32,7 +35,7 @@ function ApplicantConainer() {
           >{`${index + 1}차 모집`}</ApplicantOrder>
         ))}
       </RoundWrapper>
-      <ApplicantList userList={filterUserList} keyList={keyList} />
+      <ApplicantList userList={userList} />
     </ApplicantWrapper>
   );
 }

--- a/src/components/applicant/ApplicantList.tsx
+++ b/src/components/applicant/ApplicantList.tsx
@@ -5,15 +5,14 @@ import { IUser } from '@type/models/user';
 import ApplicantTableRow from '@src/components/applicant/ApplicantTableRow';
 
 interface IApplicantList {
-  userList: IUser[];
-  keyList: string[];
+  userList: any;
 }
 
 interface IUserObject {
   [key: string]: any;
 }
 
-function ApplicantList({ userList, keyList }: IApplicantList) {
+function ApplicantList({ userList }: IApplicantList) {
   const titleList: string[] = [
     'Num.',
     '지원날짜',
@@ -36,9 +35,10 @@ function ApplicantList({ userList, keyList }: IApplicantList) {
           ))}
         </ListTableHeadTR>
       </ListTableHead>
-      {userList.map((user: IUserObject, index: number) => (
-        <ApplicantTableRow key={index} user={user} />
-      ))}
+      {userList &&
+        userList.map((user: IUserObject, index: number) => (
+          <ApplicantTableRow key={index} user={user} />
+        ))}
     </ListTable>
   );
 }

--- a/src/components/applicant/ApplicantTableRow.tsx
+++ b/src/components/applicant/ApplicantTableRow.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
-import axios from 'axios';
 import styled from 'styled-components';
 
-interface ApplicantTableTRProps {
-  [key: string]: any;
-}
+import { patchUserWin } from '@api/adminApi';
 
 function ApplicantTableRow({ user }: any) {
-  const tableRowRef = React.useRef<any>();
+  const tableRowRef = React.useRef<HTMLTableSectionElement>(null);
+  const updateWin = patchUserWin();
 
   const handleWinStatus = (e: React.ChangeEvent<HTMLInputElement>) => {
-    console.log(tableRowRef.current.outerText);
-    console.log(e.target.checked);
+    if (tableRowRef.current) {
+      const id = parseInt(tableRowRef.current.innerText.slice(0, 1));
+      const win = e.target.checked;
+      updateWin.mutate({ id, win });
+    }
+    return;
   };
 
   return (
@@ -20,11 +22,18 @@ function ApplicantTableRow({ user }: any) {
         <ListTableTD>{user.id}</ListTableTD>
         <ListTableTD>{user.date}</ListTableTD>
         <ListTableTD>{user.name}</ListTableTD>
-        <ListTableTD>{user.sex}</ListTableTD>
+        <ListTableTD>{user.gender}</ListTableTD>
         <ListTableTD>{user.birth}</ListTableTD>
         <ListTableTD>{user.phone}</ListTableTD>
         <ListTableTD>{user.email}</ListTableTD>
-        <ListTableTD>{user.transportation}</ListTableTD>
+        <ListTableTD
+          style={{
+            overflowX: 'auto',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {user.transportation.join(', ')}
+        </ListTableTD>
         <ListTableTD>{user.region}</ListTableTD>
         <ListTableTD>
           {user.win ? (

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -33,7 +33,7 @@ export default function Admin() {
           <Download data={data} />
         </SearchContainer>
       </AdminContainer>
-      <ApplicantContainer />
+      <ApplicantContainer userList={data} setRound={setRound} />
     </>
   );
 }


### PR DESCRIPTION
## 개요
- admin 필터링 된 페이지에서 데이터를 받아옴
- 나열된 데이터들에서 합격여부 checkbox를 클릭 시, db에 데이터 변경

## 작업사항
- admin page에서 데이터 갖고와서 하위 컴포넌트에 props로 내려주기
- api에서 patchUserWin을 갖고와서 mutate를 통한 데이터 업데이트

