### PR TITLE
feat: 최대 탭 정보 전달 api 추가

### DIFF
--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { BASE_URL } from '@api/index';
 // 탭별 모든 유저 정보 가져오기(페이지네이션)
 export const fetchUsers = async ({ queryKey }) => {
@@ -36,6 +36,17 @@ export const fetchUserByPeriod = async ({ queryKey }) => {
     `${BASE_URL}/users?${type}_gte=${condition[0]}&date_lte=${condition[1]}&round=${round}&_sort=name`,
   );
   return response.data;
+};
+
+const fetchLastRound = async () => {
+  const response = await axios.get(`${BASE_URL}/users?_sort=round&_order=desc`);
+  const lastRound = await response.data[0].round;
+  const roundList = Array.from(Array(lastRound), (_, idex) => idex + 1);
+  return roundList;
+};
+
+export const getRoundList = () => {
+  return useQuery(['user', 'round'], fetchLastRound);
 };
 
 // update ----------------------------------

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -41,7 +41,7 @@ export const fetchUserByPeriod = async ({ queryKey }) => {
 const fetchLastRound = async () => {
   const response = await axios.get(`${BASE_URL}/users?_sort=round&_order=desc`);
   const lastRound = await response.data[0].round;
-  const roundList = Array.from(Array(lastRound), (_, idex) => idex + 1);
+  const roundList = Array.from(Array(lastRound), (_, index) => index + 1);
   return roundList;
 };
 


### PR DESCRIPTION
## 개요
최대 탭 (round) 전달 api 추가
## 작업사항
db 데이터 중 마지막 탭(round)을 찾아낸뒤 해당 라운드 수 만큼 배열의 요소들을 채워넣어 
ApplicationContatiner에서 라운드수만큼 mapping할수있게 로직을 맞춤
<img width="676" alt="스크린샷 2022-07-26 오후 2 12 55" src="https://user-images.githubusercontent.com/96074027/180928498-42dda742-f838-4d1c-ae91-c641ec7206f1.png">




## 사용 방법
adminApi의 getRoundList import 한뒤
```
const variable = getRoundList() 
variable.data // [1, 2, ...]

or

const {data} = getRoundLIst() // [1, 2, ...]
```
