### PR TITLE
feat: search reset 기능 추가 & filter type 생성

### DIFF
--- a/src/components/admin/search/Search.tsx
+++ b/src/components/admin/search/Search.tsx
@@ -106,8 +106,11 @@ export default function Search({ handleFilter }: ISearchProps) {
   };
   const handleReset = () => {
     if (inputRef.current) inputRef.current.value = '';
+    handleFilter({
+      type: 'select',
+      condition: '',
+    });
   };
-
   const placeholder: { [key: string]: string } = {
     select: '카테고리를 선택해주세요',
     date: 'YYYY.MM.DD 또는 YYYY.MM.DD ~ YYYY.MM.DD',

--- a/src/components/admin/search/Search.tsx
+++ b/src/components/admin/search/Search.tsx
@@ -7,7 +7,7 @@ import Select from '@components/admin/search/Select';
 import TransportationInput from '@components/admin/search/TransportationInput';
 import changeDateDBFormat from '@utils/changeDateDBFormat';
 import validateDate from '@utils/validateDate';
-import { IFilter } from '@pages/Admin';
+import { IFilter } from '@type/models/filter';
 
 const transportaions = [
   '버스',

--- a/src/components/admin/search/Select.tsx
+++ b/src/components/admin/search/Select.tsx
@@ -1,3 +1,4 @@
+import { searchSelectOptionList } from '@src/constants/admin';
 import React, { ChangeEvent } from 'react';
 import styled from 'styled-components';
 
@@ -6,15 +7,6 @@ interface SelectProps {
 }
 
 export default function Select({ changeSelectValue }: SelectProps) {
-  const searchSelectOptionList = [
-    ['선택', 'select'],
-    ['지원날짜', 'date'],
-    ['지원자명', 'name'],
-    ['성별', 'gender'],
-    ['생년월일', 'birth'],
-    ['이용수단', 'transportation'],
-    ['거주지', 'region'],
-  ];
   return (
     <SelectContainer onChange={changeSelectValue} defaultValue="select">
       {searchSelectOptionList.map(option => (

--- a/src/components/admin/search/TransportationInput.tsx
+++ b/src/components/admin/search/TransportationInput.tsx
@@ -1,15 +1,6 @@
+import { transportaions } from '@src/constants/transportation';
 import React, { ChangeEvent, KeyboardEvent, RefObject, useState } from 'react';
 import styled from 'styled-components';
-
-const transportaions = [
-  '버스',
-  '지하철',
-  '택시',
-  'KTX/기차',
-  '도보',
-  '전동킥보드',
-  '자가용',
-];
 
 interface ITransportationInputProps {
   placeholder: string;

--- a/src/constants/admin.ts
+++ b/src/constants/admin.ts
@@ -1,0 +1,34 @@
+const NUM = 'Num.';
+const SELECT = '선택';
+const DATE = '지원날짜';
+const NAME = '지원자명';
+const GENDER = '성별';
+const BIRTH = '생년월일';
+const PHONE = '연락처';
+const EMAIL = '이메일';
+const TRANSPORTATION = '이용수단';
+const REGION = '거주지';
+const WIN_OR_NOT = '당첨여부';
+
+export const titleList = [
+  NUM,
+  DATE,
+  NAME,
+  GENDER,
+  BIRTH,
+  PHONE,
+  EMAIL,
+  TRANSPORTATION,
+  REGION,
+  WIN_OR_NOT,
+];
+
+export const searchSelectOptionList = [
+  [SELECT, 'select'],
+  [DATE, 'date'],
+  [NAME, 'name'],
+  [GENDER, 'gender'],
+  [BIRTH, 'birth'],
+  [TRANSPORTATION, 'transportation'],
+  [REGION, 'region'],
+];

--- a/src/constants/transportation.ts
+++ b/src/constants/transportation.ts
@@ -1,0 +1,17 @@
+const BUS = '버스';
+const SUBWAY = '지하철';
+const TEXI = '택시';
+const TRAIN = 'KTX/기차';
+const WALKING = '도보';
+const ELECTRIC_SCOOTER = '전동킥보드';
+const CAR = '자가용';
+
+export const transportaions = [
+  BUS,
+  SUBWAY,
+  TEXI,
+  TRAIN,
+  WALKING,
+  ELECTRIC_SCOOTER,
+  CAR,
+];

--- a/src/hooks/useAdminQueries.ts
+++ b/src/hooks/useAdminQueries.ts
@@ -5,11 +5,7 @@ import {
   fetchUserBySimilarlity,
   fetchUserByPeriod,
 } from '@api/adminApi';
-
-export interface IFilter {
-  type: string;
-  condition: string | string[];
-}
+import { IFilter } from '@type/models/filter';
 
 //유즈쿼리 만들기
 function useAdminQueries(filter: IFilter, round: number) {

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -5,11 +5,7 @@ import Search from '@components/admin/search/Search';
 import Download from '@components/admin/Download';
 import ApplicantContainer from '@components/applicant/ApplicantContainer';
 import useAdminQueries from '@src/hooks/useAdminQueries';
-
-export interface IFilter {
-  type: string;
-  condition: string | string[];
-}
+import { IFilter } from '@type/models/filter';
 
 export default function Admin() {
   const [filter, setFilter] = useState<IFilter>({

--- a/src/types/models/filter.ts
+++ b/src/types/models/filter.ts
@@ -1,0 +1,4 @@
+export interface IFilter {
+  type: string;
+  condition: string | string[];
+}


### PR DESCRIPTION
## 개요
- search시 전체리스트로 다시 reset 기능 생성
- 공통으로 사용하는 filter type 분리
- 문자열 상수화

## 작업사항
- search reset 버튼에 filter state를 초기화를 통해 reset
- type 폴더안에 공통으로 사용하는 filter interface 파일을 생성
- constans 폴더안에 상수파일 생성