### PR TITLE
refactor: table css 수정 및 tableList를 상수 사용으로 변경

### DIFF
--- a/src/components/applicant/ApplicantContainer.tsx
+++ b/src/components/applicant/ApplicantContainer.tsx
@@ -37,10 +37,9 @@ function ApplicantConainer({ userList, setRound, curRound }: IApplicantProps) {
 }
 
 const ApplicantWrapper = styled.div`
-  width: 80vw;
-  height: 60vh;
+  width: 100%;
+  height: 81%;
   background: ${({ theme }) => theme.color.grey_03};
-  overflow-x: auto;
 `;
 
 const RoundWrapper = styled.div`

--- a/src/components/applicant/ApplicantList.tsx
+++ b/src/components/applicant/ApplicantList.tsx
@@ -3,25 +3,13 @@ import styled from 'styled-components';
 
 import { IAdmin } from '@type/models/user';
 import ApplicantTableRow from '@src/components/applicant/ApplicantTableRow';
+import { titleList } from '@src/constants/admin';
 
 interface IApplicantList {
   userList: IAdmin[];
 }
 
 function ApplicantList({ userList }: IApplicantList) {
-  const titleList: string[] = [
-    'Num.',
-    '지원날짜',
-    '지원자명',
-    '성별',
-    '생년월일',
-    '연락처',
-    '이메일',
-    '이용수단',
-    '거주지',
-    '당첨여부',
-  ];
-
   return (
     <ListTable>
       <ListTableHead>

--- a/src/components/applicant/ApplicantTableRow.tsx
+++ b/src/components/applicant/ApplicantTableRow.tsx
@@ -41,7 +41,9 @@ function ApplicantTableRow({ user, num }: ApplicationTableRowProps) {
   );
 }
 
-const ListTableBody = styled.tbody``;
+const ListTableBody = styled.tbody`
+  height: 25px;
+`;
 const ListTableTR = styled.tr``;
 const ListTableTD = styled.td`
   vertical-align: middle;


### PR DESCRIPTION
## 개요
- table css 조정
- 상수 사용

## 작업사항
- table에서 높이 및 가로길이 수정
- tableList를 상수를 import 해와서 사용

## 변경 및 추가 로직
```javascript
 const titleList: string[] = [
    'Num.',
    '지원날짜',
    '지원자명',
    '성별',
    '생년월일',
    '연락처',
    '이메일',
    '이용수단',
    '거주지',
    '당첨여부',
  ];
```
에서 아래로 변경

```
import { titleList } from '@src/constants/admin';
```